### PR TITLE
Register all endpoints as tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ make install
 ### Environment Variables
 - **API_KEY** - (required) H2OGPTe access key. See [documentation](https://docs.h2o.ai/enterprise-h2ogpte/guide/apis#create-an-api-key) on how to get the key.
 - **H2OGPTE_SERVER_URL** - The url of H2OGPTe server. Default value is [https://h2ogpte.genai.h2o.ai](https://h2ogpte.genai.h2o.ai).
+- **ALL_ENDPOINTS_AS_TOOLS** - A boolean flag, specifing whether all REST API endpoints should be represented as MCP tools. If disabled, GET endpoints will be represented as resources. Default value is `true`.
 
 ### Example Configuration
+An example MCP server configuration for MCP clients. E.g.: Cursor, Claude Desktop
 
 ```json
 {
@@ -42,7 +44,8 @@ make install
       "command": "h2ogpte-mcp-server",
       "env": {
         "API_KEY": "sk-...",
-        "H2OGPTE_SERVER_URL": "https://h2ogpte.genai.h2o.ai"
+        "H2OGPTE_SERVER_URL": "https://h2ogpte.genai.h2o.ai",
+        "ALL_ENDPOINTS_AS_TOOLS": true
       }
     }
   }

--- a/src/h2ogpte_mcp_server/server.py
+++ b/src/h2ogpte_mcp_server/server.py
@@ -22,7 +22,10 @@ async def start_server():
 
     # Create the MCP server
     mcp = FastMCP.from_openapi(
-        openapi_spec=openapi_spec, client=client, name="H2OGPTe MCP API server"
+        openapi_spec=openapi_spec, 
+        client=client,
+        name="H2OGPTe MCP API server",
+        all_routes_as_tools=settings.all_endpoints_as_tools
     )
 
     await register_custom_tools(mcp)

--- a/src/h2ogpte_mcp_server/settings.py
+++ b/src/h2ogpte_mcp_server/settings.py
@@ -5,6 +5,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     h2ogpte_server_url: str = Field("https://h2ogpte.genai.h2o.ai")
     api_key: str = Field()
+    all_endpoints_as_tools: bool = Field(True)
 
 
 settings = Settings()


### PR DESCRIPTION
Closes: #3

By default, fastmcp lib translates GET REST API endpoints to resource. This PR adds `ALL_ENDPOINTS_AS_TOOLS ` env variable to change that behaviour and give users export get endpoints to tools.

<img width="737" alt="Screenshot 2025-06-10 at 17 03 59" src="https://github.com/user-attachments/assets/747ccc2a-c0a4-4bc4-9a9e-f206eb2078cd" />
