### PR TITLE
fix: survive edge redirects and nullable OpenAPI enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make install
   - `basic` - A mininal set of endpoints for chatting with collections and ingesting new documents.
   - `custom` - A set of endpoints defined by the user. If chossen, the `H2OGPTE_CUSTOM_ENDPOINT_SET_FILE` variable must be set.
 - **H2OGPTE_CUSTOM_ENDPOINT_SET_FILE** - A path to file with the list of REST API endpoints. Each endpoint name must be an a separate line. The name of the endpoint is the `operationId` attribute in REST API spec file (e.g.: [https://h2ogpte.genai.h2o.ai/api-spec.yaml](https://h2ogpte.genai.h2o.ai/api-spec.yaml)) 
-- **H2OGPTE_CUSTOM_ENDPOINT_SPEC_FILE** - A path to OpenAPI spec file in YAML format describing REST API of the H2OGPTe server. If not specified, the file is obtained from the H2OGPTe server itself. This environement variable should be used only for debugging purposes.
+- **H2OGPTE_CUSTOM_OPENAPI_SPEC_FILE** - A path to OpenAPI spec file in YAML format describing REST API of the H2OGPTe server. If not specified, the file is obtained from the H2OGPTe server itself. This environement variable should be used only for debugging purposes.
 
 ### Example Configuration
 An example MCP server configuration for MCP clients. E.g.: Cursor, Claude Desktop

--- a/src/h2ogpte_mcp_server/__init__.py
+++ b/src/h2ogpte_mcp_server/__init__.py
@@ -1,10 +1,11 @@
 __version__ = "0.1.6-dev"
 
 import asyncio
-from .server import start_server
 
 
 def main():
+    from .server import start_server
+
     asyncio.run(start_server())
 
 

--- a/src/h2ogpte_mcp_server/server.py
+++ b/src/h2ogpte_mcp_server/server.py
@@ -8,6 +8,7 @@ from fastmcp.resources.resource_manager import ResourceManager
 from .settings import settings, basic_endpoints
 from .tools import register_custom_tools
 from .settings import EndpointSet
+from .spec_utils import relax_nullable_enums
 from typing import List
 
 async def start_server():
@@ -19,7 +20,9 @@ async def start_server():
 
     # Create an HTTP client for your API
     headers = {"Authorization": f"Bearer {settings.api_key}"}
-    client = httpx.AsyncClient(base_url=f"{mux_service_url}/api/v1", headers=headers)
+    client = httpx.AsyncClient(
+        base_url=f"{mux_service_url}/api/v1", headers=headers, follow_redirects=True
+    )
 
     # Default route maps for FastMCP 2.6.1
     route_maps = [
@@ -61,14 +64,16 @@ async def start_server():
 async def load_openapi_spec(mux_service_url):
     if settings.custom_openapi_spec_file:
         with open(settings.custom_openapi_spec_file, "r") as f:
-            custom_openapi_spec = yaml.load(f, Loader=yaml.CLoader)
-        return custom_openapi_spec
+            openapi_spec = yaml.load(f, Loader=yaml.CLoader)
     else:
-        client = httpx.AsyncClient(base_url=f"{mux_service_url}")
+        client = httpx.AsyncClient(base_url=f"{mux_service_url}", follow_redirects=True)
         response = await client.get("/api-spec.yaml")
         yaml_spec = response.content
         openapi_spec = yaml.load(yaml_spec, Loader=yaml.CLoader)
-        return openapi_spec
+    # Normalize OpenAPI 3.0 nullable-enum fields (e.g. Collection.vex_encryption)
+    # so strict output-schema validation accepts the null the API can return.
+    relax_nullable_enums(openapi_spec)
+    return openapi_spec
 
 
 async def remove_create_job_tools(mcp: FastMCP):

--- a/src/h2ogpte_mcp_server/settings.py
+++ b/src/h2ogpte_mcp_server/settings.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 from typing import Optional
 from enum import Enum
@@ -16,6 +16,14 @@ class Settings(BaseSettings):
     endpoint_set: EndpointSet = Field(EndpointSet.ALL_WITHOUT_ASYNC_INGEST, case_sensitive=False)
     custom_endpoint_set_file: Optional[str] = Field(None)
     custom_openapi_spec_file: Optional[str] = Field(None)
+
+    @field_validator("server_url")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str) -> str:
+        # A trailing slash yields "<url>//api/v1", which the ingress answers with
+        # a 301 redirect the client does not follow — strip it so any mistakenly
+        # configured trailing slash still works.
+        return v.rstrip("/")
 
 settings = Settings(_env_prefix="H2OGPTE_")
 basic_endpoints = [

--- a/src/h2ogpte_mcp_server/spec_utils.py
+++ b/src/h2ogpte_mcp_server/spec_utils.py
@@ -1,0 +1,25 @@
+"""Helpers for normalizing an OpenAPI spec before FastMCP builds tools from it."""
+
+
+def relax_nullable_enums(node):
+    """Recursively add ``None`` to any ``enum`` marked ``nullable: true`` that omits it.
+
+    OpenAPI 3.0 expresses a nullable enum with ``nullable: true`` *plus* the enum
+    list, but many strict validators — including the JSON-schema output validation
+    FastMCP generates for each tool — check enum membership independently of
+    ``nullable``. When the h2oGPTe API returns a real null for such a field (e.g.
+    ``Collection.vex_encryption`` is null when the collection follows the server
+    default), validation fails with ``None is not one of ['enabled', 'disabled']``.
+
+    Adding null to the enum keeps the value legal for those validators while
+    leaving every other field untouched. The ``node`` is mutated in place.
+    """
+    if isinstance(node, dict):
+        enum = node.get("enum")
+        if node.get("nullable") is True and isinstance(enum, list) and None not in enum:
+            enum.append(None)
+        for value in node.values():
+            relax_nullable_enums(value)
+    elif isinstance(node, list):
+        for value in node:
+            relax_nullable_enums(value)

--- a/tests/test_spec_utils.py
+++ b/tests/test_spec_utils.py
@@ -1,0 +1,43 @@
+from h2ogpte_mcp_server.spec_utils import relax_nullable_enums
+
+
+def test_adds_null_to_nullable_enum():
+    # Regression: Collection.vex_encryption is nullable but the enum omitted null,
+    # so a real null tripped output validation ("None is not one of [...]").
+    spec = {
+        "components": {
+            "schemas": {
+                "Collection": {
+                    "properties": {
+                        "vex_encryption": {
+                            "type": "string",
+                            "enum": ["enabled", "disabled"],
+                            "nullable": True,
+                        }
+                    }
+                }
+            }
+        }
+    }
+    relax_nullable_enums(spec)
+    assert spec["components"]["schemas"]["Collection"]["properties"]["vex_encryption"][
+        "enum"
+    ] == ["enabled", "disabled", None]
+
+
+def test_leaves_non_nullable_enum_untouched():
+    spec = {"field": {"type": "string", "enum": ["a", "b"]}}
+    relax_nullable_enums(spec)
+    assert spec["field"]["enum"] == ["a", "b"]
+
+
+def test_idempotent_when_null_already_present():
+    spec = {"field": {"enum": ["a", None], "nullable": True}}
+    relax_nullable_enums(spec)
+    assert spec["field"]["enum"] == ["a", None]
+
+
+def test_walks_nested_lists_and_dicts():
+    spec = {"oneOf": [{"enum": ["x"], "nullable": True}, {"no": "enum"}]}
+    relax_nullable_enums(spec)
+    assert spec["oneOf"][0]["enum"] == ["x", None]


### PR DESCRIPTION
## Summary

Fixes three issues that prevented the MCP server from working out-of-the-box against a real h2oGPTe instance (reproduced against a dedicated deployment). Each is independent; together they let the server list collections and call tools without any manual patching.

## The problems

1. **`HTTP error 301: Moved Permanently` on every API call.**
   `httpx` does **not** follow redirects by default, so any `3xx` from the edge broke every call. This was triggered by a **trailing slash** in `H2OGPTE_SERVER_URL`: `f"{url}/api/v1"` becomes `https://host//api/v1`, and the ingress issues a `301` to collapse the doubled slash.

2. **`None is not one of ['enabled', 'disabled']` output-validation error on `list_collections`.**
   `Collection.vex_encryption` is nullable by design (null = "follow server default"). The OpenAPI 3.0 spec marks it `nullable: true` but lists only the non-null enum values. FastMCP's generated output-schema validation checks enum membership independently of `nullable`, so a real `null` is rejected.

3. **Documented env var name was wrong.** `H2OGPTE_CUSTOM_ENDPOINT_SPEC_FILE` doesn't map to any field; the actual field is `custom_openapi_spec_file` → `H2OGPTE_CUSTOM_OPENAPI_SPEC_FILE`.

## The fixes

| Commit | Change |
|--------|--------|
| `fix(server)` | `follow_redirects=True` on both httpx clients; `relax_nullable_enums()` rewrites the fetched spec so any `nullable: true` enum includes `null`; heavy `from .server import ...` moved into `main()` so the util is unit-testable. |
| `fix(settings)` | `server_url` validator strips trailing slashes at the source. |
| `docs` | Correct env var name to `H2OGPTE_CUSTOM_OPENAPI_SPEC_FILE`. |

`relax_nullable_enums()` is general — it fixes `vex_encryption` and any future nullable enum, and keeps output validation fully enabled everywhere else (unlike disabling validation wholesale in FastMCP's `openapi.py`).

## Tests

`tests/test_spec_utils.py` — 4 cases (adds null to a nullable enum, leaves non-nullable enums untouched, idempotent when null already present, walks nested lists/dicts). **All pass.**

## Related

The nullable-enum root cause is also being fixed on the server side in `h2oai/h2ogpte` by adding `null` to the `Collection.vex_encryption` enum in `rest_api_spec_h2ogpte.yaml`. This MCP-side fix is independent and works against instances that don't yet carry that server change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
